### PR TITLE
Jax TPColumnwise

### DIFF
--- a/ddlb/benchmark.py
+++ b/ddlb/benchmark.py
@@ -38,6 +38,7 @@ def _benchmark_worker_entry(
             'compute_only': ('ddlb.primitives.TPColumnwise.compute_only', 'ComputeOnlyTPColumnwise'),
             'fuser': ('ddlb.primitives.TPColumnwise.fuser', 'FuserTPColumnwise'),
             'transformer_engine': ('ddlb.primitives.TPColumnwise.transformer_engine', 'TransformerEngineTPColumnwise'),
+            'jax': ('ddlb.primitives.TPColumnwise.jax_tp', 'JAXTPColumnwise'),
         }
         if base_impl not in mapping:
             raise ValueError(f"Unknown implementation: {base_impl}")

--- a/ddlb/primitives/TPColumnwise/__init__.py
+++ b/ddlb/primitives/TPColumnwise/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     'ComputeOnlyTPColumnwise',
     'FuserTPColumnwise',
     'TransformerEngineTPColumnwise',
+    'JAXTPColumnwise',
 ]
 
 # Lazy attribute-based imports to avoid importing optional heavy deps (e.g.,
@@ -22,7 +23,7 @@ if _typing.TYPE_CHECKING:  # for type checkers only; does not execute at runtime
     from .compute_only import ComputeOnlyTPColumnwise  # noqa: F401
     from .fuser import FuserTPColumnwise  # noqa: F401
     from .transformer_engine import TransformerEngineTPColumnwise  # noqa: F401
-
+    from .jax_tp import JAXTPColumnwise  # noqa: F401
 
 def __getattr__(name):
     if name == 'PyTorchTPColumnwise':
@@ -33,4 +34,6 @@ def __getattr__(name):
         return importlib.import_module('.fuser', __name__).FuserTPColumnwise
     if name == 'TransformerEngineTPColumnwise':
         return importlib.import_module('.transformer_engine', __name__).TransformerEngineTPColumnwise
+    if name == 'JAXTPColumnwise':
+        return importlib.import_module('.jax_tp', __name__).JAXTPColumnwise
     raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/ddlb/primitives/TPColumnwise/jax_tp.py
+++ b/ddlb/primitives/TPColumnwise/jax_tp.py
@@ -92,25 +92,25 @@ class JAXTPColumnwise(TPColumnwise):
         key_A, key_B = jax.random.split(key)
         
         # Generate unsharded matrix A with uniform distribution in [-1, 1]
-        self.A_unsharded = 2 * jax.random.uniform(
+        self.A_unsharded = jax.random.uniform(
             key_A,
             shape=(self.m, self.k),
             dtype=jax_dtype,
-            minval=0, 
+            minval=-1, 
             maxval=1
-        ) - 1
+        )
 
         # Shard A across devices - convert to sharded array
         self.A = jax.device_put(self.A_unsharded, self.A_sharding)
 
         # Generate matrix B with uniform distribution in [-1, 1]
-        B_full = 2 * jax.random.uniform(
+        B_full = jax.random.uniform(
             key_B,
             shape=(self.k, self.n),
             dtype=jax_dtype,
-            minval=0,
+            minval=-1,
             maxval=1
-        ) - 1
+        )
         
         # Replicate B across all devices
         self.B = jax.device_put(B_full, self.B_sharding)
@@ -186,4 +186,3 @@ class JAXTPColumnwise(TPColumnwise):
         # Compare results using JAX's allclose
         assert jnp.allclose(result, reference, rtol=0, atol=atol), \
             f"Result validation failed. Max difference: {jnp.max(jnp.abs(result - reference))}"
-

--- a/ddlb/primitives/TPColumnwise/jax_tp.py
+++ b/ddlb/primitives/TPColumnwise/jax_tp.py
@@ -72,7 +72,7 @@ class JAXTPColumnwise(TPColumnwise):
         # on the tp axis based on the in and out shardings
         compute_jit = jax.jit(
             lambda A_shard, B_full: jnp.matmul(A_shard, B_full),
-            in_shardings=(P('tp'), P(None)),
+            in_shardings=(self.A_sharding, self.B_sharding),
             out_shardings=self.result_sharding
         )
 

--- a/ddlb/primitives/TPColumnwise/jax_tp.py
+++ b/ddlb/primitives/TPColumnwise/jax_tp.py
@@ -1,0 +1,189 @@
+"""
+JAX implementation of TP Column-wise primitive
+"""
+
+import os
+import jax
+import jax.numpy as jnp
+from jax.experimental import multihost_utils
+from jax.experimental.shard_map import shard_map
+from jax.sharding import Mesh, PartitionSpec as P, NamedSharding
+from typing import Optional
+
+from .tp_columnwise import TPColumnwise
+from .utils import OptionsManager
+
+class JAXTPColumnwise(TPColumnwise):
+    """
+    JAX implementation of TP Column-wise primitive using JAX's distributed communication.
+    Performs Allgather on A followed by matrix multiplication with B.
+    
+    Uses JAX's mesh and sharding for distributed computation across multiple devices.
+    
+    The order of operations can be controlled using the 'order' option:
+    - 'AG_before': First perform allgather, then matmul (default)
+    - 'AG_after': First perform local matmul, then allgather results
+    """
+    
+    DEFAULT_OPTIONS = {
+        'order': 'AG_before'  # Default order
+    }
+    
+    ALLOWED_VALUES = {
+        'order': ['AG_before', 'AG_after']
+    }
+    
+    def __init__(self, *args, **kwargs):
+        # Initialize JAX distributed before parent init
+        rank = int(os.getenv("OMPI_COMM_WORLD_RANK", "0"))
+        world = int(os.getenv("OMPI_COMM_WORLD_SIZE", "1"))
+        coord = os.getenv("JAX_COORD_ADDR", "127.0.0.1:12355")  # export this via mpirun
+
+        if coord == "127.0.0.1:12355":
+            print("Export JAX_COORD_ADDR=<some_host_in_job>:12355")
+
+        jax.distributed.initialize(
+            coordinator_address=coord,
+            num_processes=world,
+            process_id=rank,
+        )
+
+        print(f"JAX initialized with {world} processes, rank {rank}, coord {coord}")
+        
+        # Create device mesh for distributed computation
+        # Assumes devices are arranged in a single row for tensor parallelism
+        devices = jax.devices()
+
+        self.mesh = Mesh(devices, axis_names=('tp',))
+        
+        # Set up sharding specs before parent init calls _input_setup
+        self.A_sharding = NamedSharding(self.mesh, P('tp', None))  # Shard along first dim
+        self.B_sharding = NamedSharding(self.mesh, P(None, None))  # Replicated
+        self.result_sharding = NamedSharding(self.mesh, P(None, None))  # Replicated
+        
+        # Now call parent init which will call _input_setup
+        super().__init__(*args, **kwargs)
+        
+        # Get allgather order after options are parsed
+        self.order = self.options['order']
+
+    def __del__(self):
+        # JAX distributed cleanup happens automatically
+        pass
+
+    def _input_setup(self):
+        """
+        Generate random matrices for the operation using JAX arrays.
+        Private method called during initialization.
+        """
+        # Map string dtypes to JAX dtypes
+        dtype_map = {
+            'float32': jnp.float32,
+            'float64': jnp.float64,
+            'float16': jnp.float16,
+            'bfloat16': jnp.bfloat16,
+            'int32': jnp.int32,
+            'int64': jnp.int64
+        }
+        jax_dtype = dtype_map.get(self.dtype, jnp.float32)
+        
+        # Set JAX random key for reproducibility
+        key = jax.random.PRNGKey(42)  # Use same seed as torch version
+        key_A, key_B = jax.random.split(key)
+        
+        # Generate unsharded matrix A with uniform distribution in [-1, 1]
+        self.A_unsharded = 2 * jax.random.uniform(
+            key_A,
+            shape=(self.m, self.k),
+            dtype=jax_dtype,
+            minval=0, 
+            maxval=1
+        ) - 1
+
+        # Shard A across devices - convert to sharded array
+        self.A = jax.device_put(self.A_unsharded, self.A_sharding)
+
+        # Generate matrix B with uniform distribution in [-1, 1]
+        B_full = 2 * jax.random.uniform(
+            key_B,
+            shape=(self.k, self.n),
+            dtype=jax_dtype,
+            minval=0,
+            maxval=1
+        ) - 1
+        
+        # Replicate B across all devices
+        self.B = jax.device_put(B_full, self.B_sharding)
+
+    def run(self) -> jnp.ndarray:
+        """
+        Run the TP Column-wise operation.
+        
+        Returns:
+            jnp.ndarray: Result matrix of shape (m, n)
+        """
+        if self.order == 'AG_before':
+            def _compute_ag_before(A_shard, B_full):
+                """Allgather first, then matmul"""
+                A_gathered = jax.lax.all_gather(A_shard, axis_name='tp', axis=0, tiled=True)
+                return jnp.matmul(A_gathered, B_full)
+            
+            sharded_fn = shard_map(
+                _compute_ag_before,
+                mesh=self.mesh,
+                in_specs=(P('tp', None), P(None, None)),  # A sharded, B replicated
+                out_specs=P(None, None),  # Result replicated
+                check_rep=False
+            )
+            return sharded_fn(self.A, self.B)
+            
+        else:  # AG_after
+            def _compute_ag_after(A_shard, B_full):
+                """Matmul first, then allgather results"""
+                local_result = jnp.matmul(A_shard, B_full)
+                return jax.lax.all_gather(local_result, axis_name='tp', axis=0, tiled=True)
+            
+            sharded_fn = shard_map(
+                _compute_ag_after,
+                mesh=self.mesh,
+                in_specs=(P('tp', None), P(None, None)),  # A sharded, B replicated
+                out_specs=P(None, None),  # Result replicated
+                check_rep=False
+            )
+            return sharded_fn(self.A, self.B)
+
+    def get_inputs(self):
+        """
+        Get the input matrices for this GPU.
+        
+        Returns:
+            Tuple of (A, B) JAX arrays where:
+            - A is the sharded portion
+            - B is replicated 
+        """
+        return self.A, self.B
+
+    def validate(self, result: jnp.ndarray):
+        """
+        Validate the result by comparing with a single-device computation.
+        
+        Args:
+            result: The result matrix from distributed computation
+            
+        Raises:
+            AssertionError: If the result doesn't match the reference computation
+        """
+        # Compute reference result
+        reference = jnp.matmul(self.A_unsharded, self.B)
+
+        # Set tolerance based on dtype
+        if result.dtype in (jnp.float16, jnp.bfloat16):
+            atol = 1e-3
+        else:
+            atol = 1e-4
+        atol *= self.k  # for accumulated error
+
+        # Compare results using JAX's allclose
+        assert jnp.allclose(result, reference, rtol=0, atol=atol), \
+            f"Result validation failed. Max difference: {jnp.max(jnp.abs(result - reference))}"
+

--- a/ddlb/primitives/TPColumnwise/jax_tp.py
+++ b/ddlb/primitives/TPColumnwise/jax_tp.py
@@ -6,14 +6,10 @@ import os
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.experimental import multihost_utils
-from jax.experimental.shard_map import shard_map
-from jax.sharding import Mesh, PartitionSpec as P, NamedSharding
-from typing import Optional
+from jax.sharding import PartitionSpec as P, NamedSharding
 import torch
 
 from .tp_columnwise import TPColumnwise
-from .utils import OptionsManager
 
 class JAXTPColumnwise(TPColumnwise):
     """

--- a/ddlb/primitives/TPColumnwise/jax_tp.py
+++ b/ddlb/primitives/TPColumnwise/jax_tp.py
@@ -18,22 +18,12 @@ from .utils import OptionsManager
 class JAXTPColumnwise(TPColumnwise):
     """
     JAX implementation of TP Column-wise primitive using JAX's distributed communication.
-    Performs Allgather on A followed by matrix multiplication with B.
     
-    Uses JAX's mesh and sharding for distributed computation across multiple devices.
-    
-    The order of operations can be controlled using the 'order' option:
-    - 'AG_before': First perform allgather, then matmul (default)
-    - 'AG_after': First perform local matmul, then allgather results
+    Uses JAX's mesh and sharding for distributed matmul
     """
-    
-    DEFAULT_OPTIONS = {
-        'order': 'AG_before'  # Default order
-    }
-    
-    ALLOWED_VALUES = {
-        'order': ['AG_before', 'AG_after']
-    }
+
+    DEFAULT_OPTIONS = {}
+    ALLOWED_VALUES = {}
     
     def __init__(self, *args, **kwargs):
         # Initialize JAX distributed before parent init
@@ -51,33 +41,23 @@ class JAXTPColumnwise(TPColumnwise):
         )
 
         print(f"JAX initialized with {world} processes, rank {rank}, coord {coord}")
-        
-        # Create device mesh for distributed computation
-        # In distributed mode, we need to create a mesh that spans all processes
-        # Each process will have its local devices, but the mesh represents the global topology
         devices = jax.devices()
-        
-        # For distributed tensor parallelism, create mesh with world_size processes
-        # Each process contributes its local devices to the global mesh
-        self.mesh = jax.make_mesh(axis_shapes=(len(devices),), axis_names=('tp',), axis_types=(jax.sharding.AxisType.Explicit,))
+
+        self.mesh = jax.make_mesh(axis_shapes=(len(devices),), axis_names=('tp',))
         jax.set_mesh(self.mesh)
 
-        # Set up sharding specs before parent init calls _input_setup
         self.A_sharding = NamedSharding(self.mesh, P('tp'))  # Shard along first dim
         self.B_sharding = NamedSharding(self.mesh, P(None))  # Replicated
         self.result_sharding = NamedSharding(self.mesh, P(None))  # Replicated
         
-        # Now call parent init which will call _input_setup
+        # Call parent init which will call _input_setup
         super().__init__(*args, **kwargs)
-        
-        # Get allgather order after options are parsed
-        self.order = self.options['order']
 
-    # This will hold the torch tensors as well in memory
+    # Note: This will hold the torch tensors in memory as well
+    # TODO: Does this change the performance at all?
     def _input_setup(self):
         super()._input_setup()
         self.A_jax = jax.numpy.asarray(self.A_unsharded, device=self.A_sharding)
-        #self.A_unsharded = jax.numpy.asarray(self.A_unsharded, device=self.B_sharding)
         self.B_jax = jax.numpy.asarray(self.B.cpu(), device=self.B_sharding)
 
     def run(self) -> jnp.ndarray:
@@ -87,24 +67,16 @@ class JAXTPColumnwise(TPColumnwise):
         Returns:
             jnp.ndarray: Result matrix of shape (m, n)
         """
-        def _compute_ag_before(A_shard, B_full):
-            """Allgather first, then matmul"""
-            A_gathered = jax.lax.all_gather(A_shard, axis_name='tp', axis=0, tiled=True)
-            return jnp.matmul(A_gathered, B_full)
 
-        def _compute_ag_after(A_shard, B_full):
-            """Matmul first, then allgather results"""
-            local_result = jnp.matmul(A_shard, B_full)
-            return jax.lax.all_gather(local_result, axis_name='tp', axis=0, tiled=True)
-        
-        sharded_fn = shard_map(
-            _compute_ag_before if self.order == 'AG_before' else _compute_ag_after,
-            mesh=self.mesh,
-            in_specs=(P('tp'), P(None)),  # A sharded, B replicated
-            out_specs=P(None),  # Result replicated
-            check_rep=False
+        # The jax jit compiler will automatically parallelize the computation
+        # on the tp axis based on the in and out shardings
+        compute_jit = jax.jit(
+            lambda A_shard, B_full: jnp.matmul(A_shard, B_full),
+            in_shardings=(P('tp'), P(None)),
+            out_shardings=self.result_sharding
         )
-        return sharded_fn(self.A_jax, self.B_jax)
+
+        return compute_jit(self.A_jax, self.B_jax)
 
     def validate(self, result: jnp.ndarray):
         result.block_until_ready()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ numpy>=1.21.0
 mpi4py>=3.1.0
 matplotlib>=3.5.0
 pandas>=1.3.0
-transformer-engine>=0.12.0 
+transformer-engine>=0.12.0
+jax[cuda13]

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -28,6 +28,11 @@
                     "multiple_process_groups": [true, false]
                 }
             ],
+            "jax": [
+                {
+                    "order": ["AG_before", "AG_after"]
+                }
+            ],
             "transformer_engine": [
                 {}
             ]

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -28,12 +28,10 @@
                     "multiple_process_groups": [true, false]
                 }
             ],
-            "jax": [
-                {
-                    "order": ["AG_before", "AG_after"]
-                }
-            ],
             "transformer_engine": [
+                {}
+            ],
+            "jax": [
                 {}
             ]
         }


### PR DESCRIPTION
The performance with Jax (AG before/after) looks like this:

```
Benchmark Results:
                                                      config Throughput (TFLOPS)  mean_time (ms)    std_time    min_time    max_time
0                                      jax (order=AG_before)       229.5 (±59.0)      153.310363   19.711268  143.927750  236.601212
1                                       jax (order=AG_after)        237.6 (±8.6)      148.085000    2.682222  141.875015  153.532486
2                    pytorch (backend=nccl, order=AG_before)       509.2 (±26.8)       69.103983    1.818642   64.535072   73.113693
3                     pytorch (backend=nccl, order=AG_after)     1273.7 (±211.1)       27.624001    2.289066   25.869247   34.101151
4                    fuser (algorithm=default, backend=nccl)       513.8 (±29.5)       68.484410    1.968136   64.307037   71.888191
5  fuser (algorithm=coll_pipeline, s=2, backend=ucc/tl/nccl)      353.5 (±551.3)       99.519528   77.590529   61.180641  362.669952
6  fuser (algorithm=coll_pipeline, s=8, backend=ucc/tl/nccl)      301.7 (±562.1)      116.627822  108.653420   63.820671  590.251221
```

I believe the issue is that Jax is recompiling the kernel on every iteration, even though the input shapes are the same. `JAX_LOG_COMPILES=1` seems to indicate this, as well as my nsys profile:

<img width="2094" height="1250" alt="image" src="https://github.com/user-attachments/assets/cda4d121-740d-443c-97a1-b39e7a2c8f5d" />
