### PR TITLE
Iterating on shapes and write to csv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,7 @@ credentials*
 # For example:
 # my_secret_config.ini
 # data/large_dataset_files/
+results/
 
 # Development environment
 .devcontainer.json

--- a/ddlb/cli/benchmark.py
+++ b/ddlb/cli/benchmark.py
@@ -136,16 +136,7 @@ def run_benchmark(config: dict) -> None:
     # Only rank 0 prints and plots results
     if rank == 0:
         print("\nBenchmark Results:")
-        
-        # Calculate TFLOPS per row: 2 * m * n * k / time
-        results['Throughput (TFLOPS)'] = (
-            2 * results['m'] * results['n'] * results['k'] / (results['mean_time (ms)'] * 1e9)
-        )
-        # Interval error (approx.): 2 * std_time scaled similarly
-        results['Throughput Interval error'] = (
-            2 * (2 * results['m'] * results['n'] * results['k']) * results['std_time'] / (results['mean_time (ms)']**2 * 1e9)
-        )
-        
+
         # Create a more readable implementation name that includes options
         def format_config(x):
             opts = implementation_options[x]
@@ -157,14 +148,6 @@ def run_benchmark(config: dict) -> None:
         
         results['config'] = results['implementation'].apply(format_config)
         
-        # Format throughput with standard deviation
-        def format_throughput(row):
-            mean = round(row['Throughput (TFLOPS)'], 1)
-            error = round(row['Throughput Interval error'], 1)
-            return f"{mean} (±{error})"
-        
-        results['Throughput (TFLOPS)'] = results.apply(format_throughput, axis=1)
-        
         # Display results (aggregated across shapes)
-        cols = ['m', 'n', 'k', 'config', 'Throughput (TFLOPS)', 'mean_time (ms)', 'std_time', 'min_time', 'max_time']
+        cols = ['m', 'n', 'k', 'config', 'Throughput (TFLOPS)', 'Throughput std (TFLOPS)', 'mean_time (ms)', 'std_time', 'min_time', 'max_time']
         print(results[cols])

--- a/ddlb/cli/benchmark.py
+++ b/ddlb/cli/benchmark.py
@@ -137,16 +137,8 @@ def run_benchmark(config: dict) -> None:
     if rank == 0:
         print("\nBenchmark Results:")
 
-        # Create a more readable implementation name that includes options
-        def format_config(x):
-            opts = implementation_options[x]
-            impl = opts['implementation']
-            other_opts = {k: v for k, v in opts.items() if k != 'implementation'}
-            if other_opts:
-                return f"{impl} ({', '.join(f'{k}={v}' for k, v in other_opts.items())})"
-            return impl
-        
-        results['config'] = results['implementation'].apply(format_config)
+        # The 'implementation' column is already a human-readable label including options
+        results['config'] = results['implementation']
         
         # Display results (aggregated across shapes)
         cols = ['m', 'n', 'k', 'config', 'Throughput (TFLOPS)', 'Throughput std (TFLOPS)', 'mean_time (ms)', 'std_time', 'min_time', 'max_time']

--- a/ddlb/primitives/TPColumnwise/fuser.py
+++ b/ddlb/primitives/TPColumnwise/fuser.py
@@ -153,7 +153,6 @@ class FuserTPColumnwise(TPColumnwise):
         'backend': 'nccl',  # Default backend
         'order': 'AG_before',  # Default order
         'algorithm': 'default',
-        'multiple_process_groups': False,
         's': 8  # Default pipeline size
     }
     
@@ -161,7 +160,6 @@ class FuserTPColumnwise(TPColumnwise):
         'backend': ['nccl', 'ucc', 'ucc/tl/nccl', 'ucc/tl/cuda', 'cuda'],
         'order': ['AG_before', 'AG_after'],
         'algorithm': ['default', 'coll_pipeline', 'p2p_pipeline'],
-        'multiple_process_groups': [True, False],
         's': (1, float('inf'))  # Allow any positive integer
     }
     
@@ -185,8 +183,6 @@ class FuserTPColumnwise(TPColumnwise):
         # Set up environment variables (include nvFuser flags)
         _env_vars = setup_ucc_env_vars(backend)
         enable_flags = []
-        if self.options.get('multiple_process_groups', False):
-            enable_flags.append('multiple_process_groups')
         if self.order == 'AG_after':
             enable_flags.append('insert_resharding_after')
         if enable_flags:

--- a/ddlb/primitives/TPColumnwise/transformer_engine.py
+++ b/ddlb/primitives/TPColumnwise/transformer_engine.py
@@ -52,7 +52,7 @@ class TransformerEngineTPColumnwise(TPColumnwise):
                                 use_fp8=False,
                                 dtype=self.torch_dtype,
                                 ub_cfgs=None,
-                                bootstrap_backend=None)
+                                bootstrap_backend="nccl")
 
         self.layer = self._te.Linear(
             in_features=self.k,

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -8,6 +8,7 @@
         "validate": true,
         "num_iterations": 50,
         "num_warmups": 5,
+        "output_csv": "results/tp_columnwise_results_{timestamp}.csv",
         "implementations": {
             "compute_only": [
                 {

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -24,8 +24,7 @@
                     "algorithm": ["coll_pipeline"],
                     "backend": ["ucc/tl/nccl"],
                     "order": ["AG_before"],
-                    "s": [8],
-                    "multiple_process_groups": [true, false]
+                    "s": [8]
                 }
             ],
             "transformer_engine": [

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,14 +1,25 @@
 {
     "benchmark": {
         "primitive": "tp_columnwise",
-        "m": 16384,
-        "n": 16384,
-        "k": 16384,
+        "m": [1024, 8192, 16384, 32768],
+        "n": [128, 1024, 16384],
+        "k": [1024, 8192, 16384],
         "dtype": "float16",
         "validate": true,
         "num_iterations": 50,
         "num_warmups": 5,
         "implementations": {
+            "compute_only": [
+                {
+                    "size": ["sharded", "unsharded"]
+                }
+            ],
+            "pytorch": [
+                {
+                    "backend": ["nccl"],
+                    "order": ["AG_before", "AG_after"]
+                }
+            ],
             "fuser": [
                 {
                     "algorithm": ["default"],


### PR DESCRIPTION
- supports having lists of `m`, `k`, `n` hyperparameters. I had to change ub's bootstrap method in TE, otherwise it would crash on the second call to `_te.module.base.initialize_ub`
- writes result to a csv file. Write results after each runner instance is done so we don't loose intermediate results if it crashes.
- removes a deprecated option to use multiple pgs in Fuser