### PR TITLE
Add option for time measurement and barrier at each iteration

### DIFF
--- a/ddlb/benchmark.py
+++ b/ddlb/benchmark.py
@@ -27,9 +27,12 @@ def _benchmark_worker_entry(
     impl_opts: Dict,
     validate: bool,
     result_queue,
+    time_measurement_backend: str = 'cpu_clock',
+    barrier_at_each_iteration: bool = True,
 ):
     # Import CUDA-dependent libraries inside child process only and lazily
     import torch
+    import torch.distributed as dist
     import numpy as _np
     import importlib as _importlib
     import socket as _socket
@@ -90,18 +93,88 @@ def _benchmark_worker_entry(
         for i in range(num_warmups):
             impl.run()
 
-        # CUDA timing events
-        start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iterations)]
-        end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iterations)]
+        # Timing loop based on backend configuration
+        times = []
+        
+        if time_measurement_backend == 'cuda_event':
+            if barrier_at_each_iteration:
+                start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iterations)]
+                end_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iterations)]
+                
+                for i in range(num_iterations):
+                    # NCCL allreduce + wait
+                    dummy = torch.tensor([0], device=impl.communicator.device, dtype=torch.int)
+                    if dist.is_initialized():
+                        dist.all_reduce(dummy)
+                        torch.cuda.synchronize()
+                    
+                    start_events[i].record()
+                    last_result = impl.run()
+                    end_events[i].record()
+                
+                torch.cuda.synchronize()
+                times = [start_events[i].elapsed_time(end_events[i]) for i in range(num_iterations)]
+            else:
+                 # Aggregate measurement without barrier
+                 start_event = torch.cuda.Event(enable_timing=True)
+                 end_event = torch.cuda.Event(enable_timing=True)
+                 
+                 torch.cuda.synchronize()
+                 start_event.record()
+                 for i in range(num_iterations):
+                     last_result = impl.run()
+                 end_event.record()
+                 
+                 torch.cuda.synchronize()
+                 total_time_ms = start_event.elapsed_time(end_event)
+                 mean_time = float(total_time_ms / num_iterations)
+                 times = [mean_time] * num_iterations
+            
+        elif time_measurement_backend == 'cpu_clock':
+            if barrier_at_each_iteration:
+                # Per-iteration measurement with barrier
+                for i in range(num_iterations):
+                    impl.communicator.barrier()
+                    
+                    start_time = time.perf_counter()
+                    last_result = impl.run()
+                    torch.cuda.synchronize()
+                    end_time = time.perf_counter()
+                    
+                    times.append((end_time - start_time) * 1000)
+            else:
+                # Aggregate measurement without barrier
+                torch.cuda.synchronize()
+                start_time = time.perf_counter()
+                
+                for i in range(num_iterations):
+                    last_result = impl.run()
+                    
+                torch.cuda.synchronize()
+                end_time = time.perf_counter()
+                
+                total_time_ms = (end_time - start_time) * 1000
+                mean_time = float(total_time_ms / num_iterations)
+                times = [mean_time] * num_iterations
+        else:
+            raise ValueError(f"Unknown time_measurement_backend: {time_measurement_backend}")
 
-        last_result = None
-        for i in range(num_iterations):
-            start_events[i].record()
-            last_result = impl.run()
-            end_events[i].record()
-
-        torch.cuda.synchronize()
-        times = [start_events[i].elapsed_time(end_events[i]) for i in range(num_iterations)]
+        # AllReduce times vector with MAX operator across ranks
+        times_tensor = torch.tensor(times, device=impl.communicator.device, dtype=torch.float64)
+        if not dist.is_initialized():
+             # Initialize process group if not already initialized
+             master_addr = os.environ.get('DDLB_MASTER_ADDR', 'localhost')
+             master_port = os.environ.get('DDLB_MASTER_PORT', '12345')
+             dist.init_process_group(
+                backend='nccl',
+                rank=impl.communicator.rank,
+                world_size=impl.communicator.world_size,
+                init_method=f"tcp://{master_addr}:{master_port}",
+                device_id=impl.communicator.device
+            )
+        dist.all_reduce(times_tensor, op=dist.ReduceOp.MAX)
+        times = times_tensor.tolist()
+        
         mean_time = float(_np.mean(times))
         std_time = float(_np.std(times))
 
@@ -145,6 +218,8 @@ def _benchmark_worker_entry(
             'Throughput std (TFLOPS)': std_throughput,
             'world_size': world_size,
             'hostname': hostname,
+            'time_measurement_backend': time_measurement_backend,
+            'barrier_at_each_iteration': barrier_at_each_iteration,
             'option': option_str,
         }
 
@@ -191,6 +266,8 @@ class PrimitiveBenchmarkRunner:
         num_warmups: int = 2,
         implementation_options: Optional[Dict[str, Dict]] = None,
         output_csv: Optional[str] = None,
+        time_measurement_backend: str = 'cpu_clock',
+        barrier_at_each_iteration: bool = True,
     ):
         """
         Initialize the benchmark runner.
@@ -206,6 +283,8 @@ class PrimitiveBenchmarkRunner:
             num_iterations: Number of iterations for timing
             num_warmups: Number of warmup iterations
             implementation_options: Optional dictionary of implementation-specific options
+            time_measurement_backend: Backend for timing ('cpu_clock' or 'cuda_event')
+            barrier_at_each_iteration: Whether to synchronize ranks before each iteration
         """
         if primitive not in self.ALLOWED_PRIMITIVES:
             raise ValueError(f"Unknown primitive: {primitive}")
@@ -221,6 +300,8 @@ class PrimitiveBenchmarkRunner:
         self.implementations = implementations
         self.implementation_options = implementation_options or {}
         self.output_csv = output_csv
+        self.time_measurement_backend = time_measurement_backend
+        self.barrier_at_each_iteration = barrier_at_each_iteration
     
     # _create_implementation is intentionally omitted in favor of per-impl subprocesses
     
@@ -269,7 +350,7 @@ class PrimitiveBenchmarkRunner:
             result_queue = ctx.SimpleQueue()
             proc = ctx.Process(
                 target=_benchmark_worker_entry,
-                args=(impl_id, self.m, self.n, self.k, self.dtype, self.num_warmups, self.num_iterations, impl_opts, self.validate, result_queue),
+                args=(impl_id, self.m, self.n, self.k, self.dtype, self.num_warmups, self.num_iterations, impl_opts, self.validate, result_queue, self.time_measurement_backend, self.barrier_at_each_iteration),
             )
             proc.start()
             result_row = result_queue.get()

--- a/ddlb/cli/benchmark.py
+++ b/ddlb/cli/benchmark.py
@@ -138,6 +138,8 @@ def run_benchmark(config: dict) -> None:
     num_iterations = benchmark_config['num_iterations']
     num_warmups = benchmark_config['num_warmups']
     output_csv: Optional[str] = benchmark_config.get('output_csv')
+    time_measurement_backend = benchmark_config.get('time_measurement_backend', 'cpu_clock')
+    barrier_at_each_iteration = benchmark_config.get('barrier_at_each_iteration', True)
 
     # Generate all possible combinations of configurations
     expanded_config = generate_config_combinations(benchmark_config['implementations'])
@@ -201,7 +203,9 @@ def run_benchmark(config: dict) -> None:
             num_iterations=num_iterations,
             num_warmups=num_warmups,
             implementation_options=implementation_options,
-            output_csv=output_csv_path
+            output_csv=output_csv_path,
+            time_measurement_backend=time_measurement_backend,
+            barrier_at_each_iteration=barrier_at_each_iteration
         )
         result_frames.append(runner.run())
 

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -1,9 +1,9 @@
 {
     "benchmark": {
         "primitive": "tp_columnwise",
-        "m": [1024, 8192, 16384, 32768],
-        "n": [128, 1024, 16384],
-        "k": [1024, 8192, 16384],
+        "m": [512, 1024, 2048, 8192, 16384],
+        "n": [512, 1024, 2048, 8192, 16384],
+        "k": [512, 1024, 2048, 8192, 16384],
         "dtype": "float16",
         "validate": true,
         "num_iterations": 50,
@@ -18,27 +18,28 @@
                 }
             ],
             "pytorch": [
-                {
-                    "backend": ["nccl"],
-                    "order": ["AG_before", "AG_after"]
-                }
+                {}
             ],
             "fuser": [
                 {
                     "algorithm": ["default"],
                     "backend": ["nccl"],
-                    "order": ["AG_before"]
+                },
+                {
+                    "algorithm": ["default"],
+                    "backend": ["cuda"],
+                    "multicast_protocol": ["memcpy", "multicast"]
+                },
+                {
+                    "algorithm": ["p2p_pipeline"],
+                    "backend": ["nccl"]
                 },
                 {
                     "algorithm": ["p2p_pipeline"],
                     "backend": ["cuda"],
-                    "order": ["AG_before"]
-                },
-                {
-                    "algorithm": ["coll_pipeline"],
-                    "backend": ["ucc/tl/nccl"],
-                    "order": ["AG_before"],
-                    "s": [8]
+                    "inter_stream_synchronization": [true, false],
+                    "offset_stream_indexing_by_rank": [true],
+                    "multicast_protocol": ["memcpy", "multicast"]
                 }
             ],
             "transformer_engine": [

--- a/scripts/config.json
+++ b/scripts/config.json
@@ -8,6 +8,8 @@
         "validate": true,
         "num_iterations": 50,
         "num_warmups": 5,
+        "time_measurement_backend": "cpu_clock", // possible values: "cpu_clock", "cuda_event"
+        "barrier_at_each_iteration": true,
         "output_csv": "results/tp_columnwise_results_{timestamp}.csv",
         "implementations": {
             "compute_only": [


### PR DESCRIPTION
Add two options controllable from the CLI or .json for how we perform the benchmark:
- `time_measurement_backend`: string that can be "cpu_clock" or "cuda_event"
- `barrier_at_each_iteration`: bool that controls whether to add a gpu barrier at each iteration (performed through pytorch's PG's nccl allreduce)


We also fix gathering the elapsed time accross rank by doing an Allreduce with "Max" op.