### PR TITLE
Remove broadcast from p2p algorithm, Add TE overlap

### DIFF
--- a/ddlb/benchmark.py
+++ b/ddlb/benchmark.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from tqdm import tqdm
-import nvtx
 from ddlb.envs import get_world_size, get_rank
 
 # Avoid importing CUDA-dependent primitives in the parent process.
@@ -117,8 +116,7 @@ def _benchmark_worker_entry(
         option_str = ", ".join(f"{k}={filtered_impl_option_values[k]}" for k in ordered_option_keys)
 
         for i in range(num_warmups):
-            with nvtx.annotate(f"Warmup {i} {impl_label} {option_str}", color="red"):
-                impl.run()
+            impl.run()
 
         # CUDA timing events
         start_events = [torch.cuda.Event(enable_timing=True) for _ in range(num_iterations)]
@@ -127,8 +125,7 @@ def _benchmark_worker_entry(
         last_result = None
         for i in range(num_iterations):
             start_events[i].record()
-            with nvtx.annotate(f"Iteration {i} {impl_label} {option_str}", color="red"):
-                last_result = impl.run()
+            last_result = impl.run()
             end_events[i].record()
 
         torch.cuda.synchronize()

--- a/ddlb/primitives/TPRowwise/transformer_engine.py
+++ b/ddlb/primitives/TPRowwise/transformer_engine.py
@@ -73,7 +73,7 @@ class TransformerEngineTPRowwise(TPRowwise):
             sequence_parallel=True,
             parallel_mode='row',
             tp_group=self.tp_group,
-            ub_overlap_rs=True, # Passes when set to False
+            ub_overlap_rs=False, # Passes when set to False
             tp_size=self.communicator.world_size,
             ub_name=ub_name
         ).cuda()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,4 +8,3 @@ mypy>=1.0.0
 pre-commit>=3.0.0
 sphinx>=6.0.0
 sphinx-rtd-theme>=1.0.0
-nvtx

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ matplotlib>=3.5.0
 pandas>=1.3.0
 transformer-engine>=0.12.0
 jax[cuda13]
-nvtx


### PR DESCRIPTION
TE overlap fails data validation when ub_overlap_rs=True, it passes when set to ub_overlap_rs=False.

I posted a message in TE slack asking about it here: https://nvidia.slack.com/archives/C03V462SAMS/p1769719702093229